### PR TITLE
Fix: pluginId and displayNewPosts warnings and some update 

### DIFF
--- a/desktop/desktop.scss
+++ b/desktop/desktop.scss
@@ -1,19 +1,16 @@
-@import "common/foundation/variables";
-
 .link-bottom-line {
   font-size: unset;
 }
 
 .topic-list-item .discourse-tags {
   display: block;
-  font-size: $font-down-2;
+  font-size: var(--font-down-2);
   clear: both;
 }
 
-.suggested-topics {
-  th.category {
-    width: 150px;
-  }
+.category.topic-list-data {
+  width: 150px;
+  text-align: center;
 }
 
 @media all and (max-width: 850px) {

--- a/javascripts/discourse/initializers/add-category-column.js.es6
+++ b/javascripts/discourse/initializers/add-category-column.js.es6
@@ -4,6 +4,7 @@ export default {
   initialize(container) {
     withPluginApi("0.8", api => {
       api.modifyClass("component:topic-list-item", {
+        pluginId: "add-category-column",
         titleColSpan: function() {
           return !this.get("hideCategory") &&
             this.get("topic.isPinnedUncategorized")

--- a/javascripts/discourse/templates/list/topic-list-item.raw.hbs
+++ b/javascripts/discourse/templates/list/topic-list-item.raw.hbs
@@ -59,7 +59,7 @@
 {{raw "list/posts-count-column" topic=topic}}
 
 {{#if showOpLikes}}
-  <td class="num likes">
+  <td class="num likes topic-list-data">
     {{#if hasOpLikes}}
       <a href='{{topic.summaryUrl}}'>
         {{number topic.op_like_count}} {{d-icon "heart"}}

--- a/javascripts/discourse/templates/list/topic-list-item.raw.hbs
+++ b/javascripts/discourse/templates/list/topic-list-item.raw.hbs
@@ -24,7 +24,7 @@
                                    topicId=topic.id 
                                    unreadClass=unreadClass~}}
     {{~#if showTopicPostBadges}}
-      {{~raw "topic-post-badges" unread=topic.unread newPosts=topic.displayNewPosts unseen=topic.unseen url=topic.lastUnreadUrl newDotText=newDotText}}
+      {{~raw "topic-post-badges" unreadPosts=topic.unread_posts unseen=topic.unseen url=topic.lastUnreadUrl newDotText=newDotText}}
     {{~/if}}
   </span>
 

--- a/javascripts/discourse/templates/list/topic-list-item.raw.hbs
+++ b/javascripts/discourse/templates/list/topic-list-item.raw.hbs
@@ -46,26 +46,31 @@
   {{raw "list/posters-column" posters=topic.featuredUsers}}
 {{/if}}
 
-{{raw "list/posts-count-column" topic=topic}}
-
 {{#if showLikes}}
   <td class="num likes topic-list-data">
     {{#if hasLikes}}
       <a href='{{topic.summaryUrl}}'>
-        {{number topic.like_count}} {{d-icon "heart"}}</td>
-  </a>
+        {{number topic.like_count}} {{d-icon "heart"}}
+      </a>
+    {{/if}}
+  </td>
 {{/if}}
-{{/if}}
+
+{{raw "list/posts-count-column" topic=topic}}
 
 {{#if showOpLikes}}
-  <td class="num likes topic-list-data">
+  <td class="num likes">
     {{#if hasOpLikes}}
       <a href='{{topic.summaryUrl}}'>
-        {{number topic.op_like_count}} {{d-icon "heart"}}</td>
-  </a>
-{{/if}}
+        {{number topic.op_like_count}} {{d-icon "heart"}}
+      </a>
+    {{/if}}
+  </td>
 {{/if}}
 
-<td class="num views {{topic.viewsHeat}} topic-list-data">{{number topic.views numberKey="views_long"}}</td>
+<td class="num views {{topic.viewsHeat}} topic-list-data">
+  {{raw-plugin-outlet name="topic-list-before-view-count"}}
+  {{number topic.views numberKey="views_long"}}
+</td>
 
 {{raw "list/activity-column" topic=topic class="num topic-list-data" tagName="td"}}

--- a/javascripts/discourse/templates/topic-list-header.raw.hbs
+++ b/javascripts/discourse/templates/topic-list-header.raw.hbs
@@ -1,5 +1,5 @@
 {{#if bulkSelectEnabled}}
-  <th class="bulk-select">
+  <th class="bulk-select topic-list-data">
     {{#if canBulkSelect}}
       {{raw "flat-button" class="bulk-select" icon="list" title="topics.bulk.toggle"}}
     {{/if}}
@@ -10,7 +10,7 @@
   {{raw "topic-list-header-column" sortable=sortable order='category' name='category_title'}}
 {{/unless}}
 {{#if showPosters}}
-  {{raw "topic-list-header-column" order='posters'}}
+  {{raw "topic-list-header-column" order='posters' ariaLabel=(i18n "category.sort_options.posters") forceName=(theme-i18n "users")}}
 {{/if}}
 {{raw "topic-list-header-column" sortable=sortable number='true' order='posts' name='replies'}}
 {{#if showLikes}}

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,0 +1,2 @@
+en:
+  users: "Users"


### PR DESCRIPTION
This PR fixes these warnings: https://meta.discourse.org/t/add-category-column/103893/23?u=dodesz 

And some update:
* Update template files
* Update desktop.css
* Add topic list users header title
* Add locale file to make it translate able

![Screenshot 2022-02-15 at 13 17 06](https://user-images.githubusercontent.com/71207900/154060527-3af091e1-b406-416a-9e83-23272b26652a.png)

Thanks 🙂 


